### PR TITLE
disable backface culling for modular blocks

### DIFF
--- a/Rogue-Robots/DOGEngine/src/Core/Application.cpp
+++ b/Rogue-Robots/DOGEngine/src/Core/Application.cpp
@@ -80,13 +80,21 @@ namespace DOG
 			//// ====== GPU
 			m_renderer->BeginFrame_GPU();
 
-			EntityManager::Get().Bundle<TransformComponent, ModelComponent>().Do([&](TransformComponent& transformC, ModelComponent& modelC)
+			EntityManager::Get().Collect<TransformComponent, ModelComponent>().Do([&](entity e, TransformComponent& transformC, ModelComponent& modelC)
 				{
 					ModelAsset* model = AssetManager::Get().GetAsset<ModelAsset>(modelC);
 					if (model && model->gfxModel)
 					{
-						for (u32 i = 0; i < model->gfxModel->mesh.numSubmeshes; ++i)
-							m_renderer->SubmitMesh(model->gfxModel->mesh.mesh, i, model->gfxModel->mats[i], transformC);
+						if (EntityManager::Get().HasComponent<ModularBlockComponent>(e))
+						{
+							for (u32 i = 0; i < model->gfxModel->mesh.numSubmeshes; ++i)
+								m_renderer->SubmitMeshNoFaceCulling(model->gfxModel->mesh.mesh, i, model->gfxModel->mats[i], transformC);
+						}
+						else
+						{
+							for (u32 i = 0; i < model->gfxModel->mesh.numSubmeshes; ++i)
+								m_renderer->SubmitMesh(model->gfxModel->mesh.mesh, i, model->gfxModel->mats[i], transformC);
+						}
 					}
 				});
 

--- a/Rogue-Robots/DOGEngine/src/ECS/Component.h
+++ b/Rogue-Robots/DOGEngine/src/ECS/Component.h
@@ -78,5 +78,9 @@ namespace DOG
 		bool shouldStop = false;
 	};
 
+	struct ModularBlockComponent
+	{
+		//
+	};
 }
 

--- a/Rogue-Robots/DOGEngine/src/Graphics/Rendering/Renderer.h
+++ b/Rogue-Robots/DOGEngine/src/Graphics/Rendering/Renderer.h
@@ -42,6 +42,7 @@ namespace DOG::gfx
 		void SetMainRenderCamera(const DirectX::XMMATRIX& view, DirectX::XMMATRIX* proj = nullptr);
 
 		void SubmitMesh(Mesh mesh, u32 submesh, MaterialHandle material, const DirectX::SimpleMath::Matrix& world);
+		void SubmitMeshNoFaceCulling(Mesh mesh, u32 submesh, MaterialHandle material, const DirectX::SimpleMath::Matrix& world);
 
 
 
@@ -85,6 +86,7 @@ namespace DOG::gfx
 		
 		std::unique_ptr<GraphicsBuilder> m_builder;
 		std::vector<RenderSubmission> m_submissions;		// temporary
+		std::vector<RenderSubmission> m_noCullSubmissions;	// temporary
 
 
 		DirectX::XMMATRIX m_viewMat, m_projMat;
@@ -112,7 +114,7 @@ namespace DOG::gfx
 
 		// ================= RENDERING RESOURCES
 
-		Pipeline m_pipe, m_meshPipe;
+		Pipeline m_pipe, m_meshPipe, m_meshPipeNoCull;
 		Pipeline m_testCompPipe;
 
 		// Reusing a single command list for now

--- a/Rogue-Robots/Runtime/src/Game/GameComponent.h
+++ b/Rogue-Robots/Runtime/src/Game/GameComponent.h
@@ -22,8 +22,3 @@ struct AgentStatsComponent
 	float speed;
 	//...
 };
-
-struct ModularBlockComponent
-{
-	//
-};


### PR DESCRIPTION
Warning in Renderer about stack usage has to be ignored for now.
It will be fixed in a data structure refactor in the near future.