### PR TITLE
Handle alt+f4 explicitly

### DIFF
--- a/Rogue-Robots/DOGEngine/src/Core/Window.cpp
+++ b/Rogue-Robots/DOGEngine/src/Core/Window.cpp
@@ -104,7 +104,7 @@ namespace DOG
 			}
 			if (wParam == VK_F4 && (lParam & (1 << 29) && !keyIsRepeated))
 			{
-				break; // We don't want to disable alt + f4.
+				PublishEvent<WindowClosedEvent>();  // Handle ALT+F4
 			}
 		}
 		case WM_KEYDOWN:


### PR DESCRIPTION
This fixes a bug where alt+f4 would not work when mouse cursor was hidden and we blocked some input to imgui winproc.