### PR TITLE
Shadow mapping on/off toggling finalized.

### DIFF
--- a/Rogue-Robots/Assets/Shaders/MainPS.hlsl
+++ b/Rogue-Robots/Assets/Shaders/MainPS.hlsl
@@ -33,6 +33,8 @@ struct SpotlightData
     float cutoffAngle;
     float3 direction;
     float strength;
+    bool isShadowCaster;
+    float3 padding;
 };
 
 struct SpotlightMetaData
@@ -340,7 +342,8 @@ PS_OUT main(VS_OUT input)
     //calculate dynamic spot lights
     ConstantBuffer<SpotlightMetaData> perSpotlightData = ResourceDescriptorHeap[g_constants.spotlightArrayStructureIndex];
     ConstantBuffer<Shadow> shadowMapArrayStruct = ResourceDescriptorHeap[g_constants.shadowMapDepthIndex];
-    
+    // Always 0
+    Texture2DArray shadowMaps = ResourceDescriptorHeap[shadowMapArrayStruct.shadowMapArray[0][0]];
     for (int k = 0; k < perSpotlightData.currentNrOfSpotlights; ++k)
     {
         if (perSpotlightData.spotlightArray[k].strength == 0)
@@ -398,10 +401,9 @@ PS_OUT main(VS_OUT input)
         
         //Texture2D shadowMap = ResourceDescriptorHeap[shadowMapArrayStruct.shadowMapArray[groupIndex][offsetInGroup]];
         
-        // Always 0
-        Texture2DArray shadowMaps = ResourceDescriptorHeap[shadowMapArrayStruct.shadowMapArray[0][0]];
         
-        float shadowFactor = CalculateShadowFactor(shadowMaps, k, input.wsPos, N, -lightToPosDir, perSpotlightData.spotlightArray[k].viewMatrix, perSpotlightData.spotlightArray[k].projectionMatrix);
+        float shadowFactor = perSpotlightData.spotlightArray[k].isShadowCaster ? CalculateShadowFactor(shadowMaps, k, input.wsPos, N, -lightToPosDir, perSpotlightData.spotlightArray[k].viewMatrix, perSpotlightData.spotlightArray[k].projectionMatrix) : 1.0f;
+        
         Lo += (kD * albedoInput / 3.1415 + specular) * radiance * NdotL * contrib * shadowFactor;
     }
     

--- a/Rogue-Robots/DOGEngine/src/Core/Application.cpp
+++ b/Rogue-Robots/DOGEngine/src/Core/Application.cpp
@@ -476,8 +476,15 @@ namespace DOG
 				if (ImGui::Checkbox("SSAO", &m_specification.graphicsSettings.ssao))
 					gfxChanged = true;
 
+				if (ImGui::Checkbox("Shadow Mapping", &m_specification.graphicsSettings.shadowMapping))
+				{
+					m_frontRenderer->ToggleShadowMapping(m_specification.graphicsSettings.shadowMapping);
+					gfxChanged = true;
+				}
+
 				if (ImGui::SliderFloat("Gamma", &m_specification.graphicsSettings.gamma, 1.0f, 5.0f))
 					gfxChanged = true;
+
 				ImGui::SameLine();
 				if (ImGui::Button("Default"))
 				{

--- a/Rogue-Robots/DOGEngine/src/Core/CoreUtils.h
+++ b/Rogue-Robots/DOGEngine/src/Core/CoreUtils.h
@@ -15,6 +15,11 @@ namespace DOG
 
 		bool ssao{ true };
 		bool lit{ true };
+#if defined _DEBUG
+		bool shadowMapping{ false };
+#else
+		bool shadowMapping{ true };
+#endif
 		u32 shadowMapCapacity{ 4 };
 	};
 

--- a/Rogue-Robots/DOGEngine/src/ECS/Component.h
+++ b/Rogue-Robots/DOGEngine/src/ECS/Component.h
@@ -3,7 +3,7 @@
 
 namespace DOG
 {
-	constexpr const u32 MAX_ENTITIES = 64'000u;
+	constexpr const u32 MAX_ENTITIES = 10'000u;
 	constexpr const u32 NULL_ENTITY = MAX_ENTITIES;
 	typedef u32 entity;
 

--- a/Rogue-Robots/DOGEngine/src/Graphics/Rendering/FrontRenderer.h
+++ b/Rogue-Robots/DOGEngine/src/Graphics/Rendering/FrontRenderer.h
@@ -31,6 +31,8 @@ namespace DOG::gfx
 		// ECS specifics
 		void PerformDeferredDeletion();
 
+		void ToggleShadowMapping(bool turnOn);
+
 	private:
 
 

--- a/Rogue-Robots/DOGEngine/src/Graphics/Rendering/Renderer.cpp
+++ b/Rogue-Robots/DOGEngine/src/Graphics/Rendering/Renderer.cpp
@@ -585,6 +585,8 @@ namespace DOG::gfx
 				float cutoffAngle{ 0.f };
 				DirectX::SimpleMath::Vector3 direction;
 				float strength{ 0.f };
+				bool isShadowCaster { false };
+				float padding[3];
 			};
 
 			/*Encompasses all the light datas for spotlights, which we currently limit to 12*/
@@ -785,16 +787,19 @@ namespace DOG::gfx
 					{
 						const auto& data = m_activeSpotlights[i];
 
-						perLightData.perLightDatas[i].view = data.shadow->viewMat;
-						perLightData.perLightDatas[i].proj = data.shadow->projMat;
 						perLightData.perLightDatas[i].position = data.position;
 						perLightData.perLightDatas[i].color = { data.color.x, data.color.y, data.color.z, };
 						perLightData.perLightDatas[i].direction = data.direction;
 						perLightData.perLightDatas[i].cutoffAngle = data.cutoffAngle;
 						perLightData.perLightDatas[i].strength = data.strength;
 
-						shadowMapArrayStruct.shadowMaps[i] = resources.GetView(p.shadowView);
-
+						if (data.shadow != std::nullopt)
+						{
+							perLightData.perLightDatas[i].isShadowCaster = true;
+							perLightData.perLightDatas[i].view = data.shadow->viewMat;
+							perLightData.perLightDatas[i].proj = data.shadow->projMat;
+							shadowMapArrayStruct.shadowMaps[i] = resources.GetView(p.shadowView);
+						}
 					}
 
 					perLightData.actualNrOfSpotlights = (u32)m_activeSpotlights.size();
@@ -1220,7 +1225,6 @@ namespace DOG::gfx
 
 		}
 	}
-
 
 	LRESULT Renderer::WinProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 	{

--- a/Rogue-Robots/DOGEngine/src/Graphics/Rendering/Renderer.h
+++ b/Rogue-Robots/DOGEngine/src/Graphics/Rendering/Renderer.h
@@ -104,7 +104,6 @@ namespace DOG::gfx
 		GraphicsSettings GetGraphicsSettings();
 		WindowMode GetFullscreenState() const;
 
-
 		void BeginFrame_GPU();
 		void EndFrame_GPU(bool vsync);
 

--- a/Rogue-Robots/Runtime/src/Core/RuntimeApplication.cpp
+++ b/Rogue-Robots/Runtime/src/Core/RuntimeApplication.cpp
@@ -20,6 +20,10 @@ void RuntimeApplication::OnStartUp() noexcept
 {
 	PushLayer(&m_gameLayer);
 	//PushLayer(&m_EmilFDebugLayer);
+
+	#if defined _DEBUG
+	IssueDebugFunctionality();
+	#endif
 }
 
 void RuntimeApplication::OnShutDown() noexcept
@@ -79,6 +83,15 @@ void RuntimeApplication::OnEvent(IEvent& event) noexcept
 
 	}
 	Application::OnEvent(event);
+}
+
+void RuntimeApplication::IssueDebugFunctionality() noexcept
+{
+	//Have no spotlight casts shadows by default in debug:
+	EntityManager::Get().Collect<DOG::SpotLightComponent, DOG::ShadowCasterComponent>().Do([](entity spotlight, DOG::SpotLightComponent&, DOG::ShadowCasterComponent&) 
+		{
+			EntityManager::Get().RemoveComponent<DOG::ShadowCasterComponent>(spotlight);
+		});
 }
 
 std::string GetWorkingDirectory()

--- a/Rogue-Robots/Runtime/src/Core/RuntimeApplication.h
+++ b/Rogue-Robots/Runtime/src/Core/RuntimeApplication.h
@@ -11,7 +11,8 @@ public:
 	virtual void OnShutDown() noexcept override final;
 	virtual void OnRestart() noexcept override final;
 	virtual void OnEvent(DOG::IEvent& event) noexcept final;
-
+private:
+	void IssueDebugFunctionality() noexcept;
 private:
 	bool m_showImGuiMenu = false;
 	GameLayer m_gameLayer;

--- a/Rogue-Robots/Runtime/src/Game/GameLayer.cpp
+++ b/Rogue-Robots/Runtime/src/Game/GameLayer.cpp
@@ -944,8 +944,9 @@ std::vector<entity> GameLayer::AddFlashlightsToPlayers(const std::vector<entity>
 		float fov = ((slc.cutoffAngle + 0.1f) * 2.0f) * DirectX::XM_PI / 180.f;
 		cc.projMatrix = DirectX::XMMatrixPerspectiveFovLH(fov, 1, 800.f, 0.1f);
 
+		#if defined NDEBUG
 		m_entityManager.AddComponent<DOG::ShadowCasterComponent>(flashLightEntity);
-
+		#endif
 		if (i == 0) // Only for this/main player
 			slc.isMainPlayerSpotlight = true;
 		else

--- a/Rogue-Robots/Runtime/vendor/includes/StaticTypeInfo/type_index.h
+++ b/Rogue-Robots/Runtime/vendor/includes/StaticTypeInfo/type_index.h
@@ -1,5 +1,4 @@
 #pragma once
-
 #ifndef STATIC_TYPE_INFO_USE_MEMBER_POINTER
 // enable the new implementation using member pointers on tested compilers
 // gcc currently fails as member pointers are not considered constexpr


### PR DESCRIPTION
Shadow mapping is now toggable and off by default in debug configuration. This can be seen as the first of two fixes however; a better structure can be achieved on the renderer/shader side of things.

Functionality tests: Hit F1, and go to View -> Application Settings. From there, scroll down to shadow mapping. It should be on by default in Release and off in Debug, and toggable in both modes. Click and verify that shadows does indeed disappear and reappear, and that the frame time has been improved when shadow mapping is turned off. Note however, that the effect on the frame time is way more noticable in Debug configuration, rather than in Release.