### PR TITLE
Add render graph depth aliasing support

### DIFF
--- a/Rogue-Robots/DOGEngine/src/Graphics/Rendering/RenderGraph/RenderGraph.cpp
+++ b/Rogue-Robots/DOGEngine/src/Graphics/Rendering/RenderGraph/RenderGraph.cpp
@@ -708,9 +708,7 @@ namespace DOG::gfx
 
 		// No aliasing support for depth stencil
 		if (m_globalData.writes.contains(id))
-		{
-			//assert(false);
-			
+		{			
 			// Explicitly connects previous reads on ID to newID
 			// The previous reads that are connect are the previous reads SINCE a write.
 			const auto ids = ResolveAliasingIDs(id);


### PR DESCRIPTION
Depth resources can now be aliased just like render targets