### PR TITLE
Fix for dead players to not move

### DIFF
--- a/Rogue-Robots/DOGEngine/src/Physics/PhysicsRigidbody.cpp
+++ b/Rogue-Robots/DOGEngine/src/Physics/PhysicsRigidbody.cpp
@@ -6,6 +6,8 @@
 
 namespace DOG
 {
+	using namespace DirectX::SimpleMath;
+
 	RigidbodyComponent::RigidbodyComponent(entity entity, bool kinematicBody)
 	{
 		//Can only create a rigidbody component for box, sphere, capsule
@@ -75,6 +77,15 @@ namespace DOG
 		constrainPositionX = constrainXPosition;
 		constrainPositionY = constrainYPosition;
 		constrainPositionZ = constrainZPosition;
+	}
+
+	void RigidbodyComponent::ClearPhysics()
+	{
+		linearVelocity = Vector3::Zero;
+		centralForce = Vector3::Zero;
+		centralImpulse = Vector3::Zero;
+		torque = Vector3::Zero;
+		angularVelocity = Vector3::Zero;
 	}
 
 	void PhysicsRigidbody::UpdateRigidbodies()

--- a/Rogue-Robots/DOGEngine/src/Physics/PhysicsRigidbody.h
+++ b/Rogue-Robots/DOGEngine/src/Physics/PhysicsRigidbody.h
@@ -34,6 +34,8 @@ namespace DOG
 		//With this you can rotate and change the position of the transform directly (do not change the transform every frame as this causes the physics to not work properly)
 		bool getControlOfTransform = false;
 		DirectX::SimpleMath::Vector3 lastFramePositionDifferance;
+
+		void ClearPhysics();
 	};
 
 	class PhysicsRigidbody

--- a/Rogue-Robots/Runtime/src/Game/GameLayer.cpp
+++ b/Rogue-Robots/Runtime/src/Game/GameLayer.cpp
@@ -319,6 +319,8 @@ void GameLayer::RespawnDeadPlayer(DOG::entity e) // TODO RespawnDeadPlayer will 
 	auto& controller = m_entityManager.GetComponent<PlayerControllerComponent>(e);
 	m_entityManager.DeferredEntityDestruction(controller.debugCamera);
 	controller.debugCamera = DOG::NULL_ENTITY;
+
+	m_entityManager.GetComponent<RigidbodyComponent>(e).ConstrainPosition(false, false, false);
 }
 
 void GameLayer::KillPlayer(DOG::entity e)
@@ -335,6 +337,10 @@ void GameLayer::KillPlayer(DOG::entity e)
 		std::string luaEventName = std::string("ItemPickup") + std::to_string(localPlayer);
 		m_entityManager.RemoveComponent<ScriptComponent>(localPlayer);
 		m_entityManager.RemoveComponent<BarrelComponent>(localPlayer);
+
+		RigidbodyComponent& rb = m_entityManager.GetComponent<RigidbodyComponent>(e);
+		rb.ConstrainPosition(true, true, true);
+		rb.ClearPhysics();
 
 		DOG::entity playerToSpectate = DOG::NULL_ENTITY;
 		const char* playerName{ nullptr };


### PR DESCRIPTION
Test by playing with two players, one player is in god mode and the other goes and dies.
The one in god mode should try to move the enemies to the dead player and see if they move.