### PR TITLE
Fix particle system persistence bug

### DIFF
--- a/Rogue-Robots/Assets/Shaders/Particles/EmitterCS.hlsl
+++ b/Rogue-Robots/Assets/Shaders/Particles/EmitterCS.hlsl
@@ -45,8 +45,15 @@ void main(uint globalID : SV_DispatchThreadID, uint3 threadID : SV_GroupThreadID
 		g_emitter = emitterBuffer[emitterIdx];
 	}
 	
+	GroupMemoryBarrierWithGroupSync();
+	
 	if (g_emitter.alive == 0)
+	{
+		if (threadID.x == 0)
+			toSpawnBuffer[groupID.x] = 0.f;
+		
 		return;
+	}
 	
 	if (threadID.x == 0)
 	{
@@ -58,7 +65,7 @@ void main(uint globalID : SV_DispatchThreadID, uint3 threadID : SV_GroupThreadID
 	
 	if (toSpawnBuffer[groupID.x] >= 1.f)
 	{
-		for (uint i = threadID.x; i < toSpawnBuffer[groupID.x]; i += GROUP_SIZE)
+		for (uint i = threadID.x; i < toSpawnBuffer[groupID.x] - 1.f; i += GROUP_SIZE)
 		{
 			uint lastAlive;
 			InterlockedAdd(aliveCounter[0], 1, lastAlive);

--- a/Rogue-Robots/Runtime/src/Game/TestScenes/ParticleScene.cpp
+++ b/Rogue-Robots/Runtime/src/Game/TestScenes/ParticleScene.cpp
@@ -60,8 +60,6 @@ ParticleScene::~ParticleScene()
 
 void ParticleScene::ParticleSystemMenu(bool& open)
 {
-	auto& emitter = EntityManager::Get().GetComponent<ParticleEmitterComponent>(m_particleSystem);
-
 	if (ImGui::BeginMenu("View"))
 	{
 		if (ImGui::MenuItem("Particle System"))
@@ -75,6 +73,43 @@ void ParticleScene::ParticleSystemMenu(bool& open)
 	{
 		if (ImGui::Begin("Particle System", &open))
 		{
+			static bool toggled = true;
+			if (ImGui::Button("Toggle System"))
+			{
+				toggled = !toggled;
+				if (toggled)
+				{
+					m_particleSystem = CreateEntity();
+					AddComponent<TransformComponent>(m_particleSystem, Vector3(0, 0, 0));
+					auto& em = AddComponent<ParticleEmitterComponent>(m_particleSystem);
+					em = {
+						.spawnRate = 64.f,
+						.particleSize = 0.1f,
+						.particleLifetime = 0.5f,
+						.startColor = Vector4(1, 0, 0, 1),
+						.endColor = Vector4(0, 0, 1, 1),
+					};
+
+						AddComponent<ConeSpawnComponent>(m_particleSystem) = {
+						.angle = XM_PIDIV4,
+						.speed = 10.f,
+					};
+				}
+				else
+				{
+					AddComponent<DeferredDeletionComponent>(m_particleSystem);
+				}
+			}
+			ImGui::SameLine();
+			ImGui::Text(std::to_string(toggled).c_str());
+
+			if (!toggled) {
+				ImGui::End();
+				return;
+			}
+			auto& emitter = EntityManager::Get().GetComponent<ParticleEmitterComponent>(m_particleSystem);
+			
+
 			// Spawn rate setting
 			static float rate = emitter.spawnRate;
 			ImGui::InputFloat("Rate", &rate);


### PR DESCRIPTION
Test:
Just spam the toggle button in the particle scene for a bit and make sure the particle system doesn't persist after death (i.e. the number next to the toggle button says 0)

You can also try to shoot some enemies or have the turret shoot at them, and see that no particle systems persist in the world.