### PR TITLE
Reviving now requires the necessary active item.

### DIFF
--- a/Rogue-Robots/Assets/LuaScripts/ActiveItemSystem.lua
+++ b/Rogue-Robots/Assets/LuaScripts/ActiveItemSystem.lua
@@ -19,10 +19,12 @@ function OnUpdate()
 
 	if Entity:GetAction(EntityID, "ActivateActiveItem") and activeItem then
 		if clicked == false then
-			activeEntityCreated = activeItem:activate(EntityID)
-			activeItem = nil
-			Entity:RemoveComponent(EntityID, "ActiveItem")
-			clicked = true
+			if activeItem:GetECSType() ~= 2 then -- Dont activate reviver this way, ECS handles it
+				activeEntityCreated = activeItem:activate(EntityID)
+				activeItem = nil
+				Entity:RemoveComponent(EntityID, "ActiveItem")
+				clicked = true
+			end
 		end
 	else
 		clicked = false
@@ -33,7 +35,7 @@ function OnPickup(pickup)
 	local pickupTypeString = Entity:GetEntityTypeAsString(pickup)
 	local playerID = EntityID
 
-	if pickupTypeString == "Trampoline" or pickupTypeString == "Turret" then
+	if pickupTypeString == "Trampoline" or pickupTypeString == "Turret" or pickupTypeString == "Reviver" then
 		if Entity:HasComponent(playerID, "ActiveItem") then
 			Entity:SpawnActiveItem(playerID)
 			Entity:RemoveComponent(playerID, "ActiveItem")
@@ -44,6 +46,10 @@ function OnPickup(pickup)
 		end
 		if pickupTypeString == "Turret" then
 			activeItem = ActiveItems.turret
+			Entity:AddComponent(playerID, "ActiveItem", activeItem:GetECSType())
+		end
+		if pickupTypeString == "Reviver" then
+			activeItem = ActiveItems.reviver
 			Entity:AddComponent(playerID, "ActiveItem", activeItem:GetECSType())
 		end
 	end

--- a/Rogue-Robots/Assets/LuaScripts/ActiveItems.lua
+++ b/Rogue-Robots/Assets/LuaScripts/ActiveItems.lua
@@ -75,4 +75,13 @@ ActiveItems.turret = {
 
 }
 
+ActiveItems.reviver = {
+
+	GetECSType = function(self)
+			return 2
+		end,
+
+
+}
+
 return ActiveItems

--- a/Rogue-Robots/Runtime/src/Game/EntitesTypes.h
+++ b/Rogue-Robots/Runtime/src/Game/EntitesTypes.h
@@ -26,6 +26,7 @@ enum class EntityTypes
 	ActiveItemsBegin,
 	Trampoline,
 	Turret,
+	Reviver,
 	ActiveItems,
 
 	//Barrel

--- a/Rogue-Robots/Runtime/src/Game/GameComponent.h
+++ b/Rogue-Robots/Runtime/src/Game/GameComponent.h
@@ -129,7 +129,7 @@ struct PassiveItemComponent {
 //The active item that currently resides in inventory
 struct ActiveItemComponent
 {
-	enum class Type{ Trampoline = 0, Turret };
+	enum class Type{ Trampoline = 0, Turret, Reviver };
 
 	Type type;
 };

--- a/Rogue-Robots/Runtime/src/Game/GameSystems.cpp
+++ b/Rogue-Robots/Runtime/src/Game/GameSystems.cpp
@@ -647,6 +647,13 @@ void ReviveSystem::OnUpdate(DOG::entity player, InputController& inputC, PlayerA
 {
 	DOG::EntityManager& mgr = DOG::EntityManager::Get();
 
+	//If the player that wants to perform a revive does not have a reviver active item, we ofc return:
+	auto optionalItem = mgr.TryGetComponent<ActiveItemComponent>(player);
+	if (!optionalItem)
+		return;
+	if ((*optionalItem).get().type != ActiveItemComponent::Type::Reviver)
+		return;
+
 	DOG::entity closestDeadPlayer{ NULL_ENTITY };
 	float distanceToClosestDeadPlayer{ FLT_MAX };
 
@@ -815,6 +822,8 @@ void ReviveSystem::OnUpdate(DOG::entity player, InputController& inputC, PlayerA
 			ChangeSuitDrawLogic(spectatedPlayer, closestDeadPlayer);
 			RevivePlayer(closestDeadPlayer);
 		}
+		if (mgr.HasComponent<ThisPlayer>(player))
+			mgr.RemoveComponent<ActiveItemComponent>(player);
 	}
 }
 

--- a/Rogue-Robots/Runtime/src/Game/ItemManager/ItemManager.cpp
+++ b/Rogue-Robots/Runtime/src/Game/ItemManager/ItemManager.cpp
@@ -56,6 +56,8 @@ u32 ItemManager::CreateItem(EntityTypes itemType, Vector3 position, u32 id)
 		//break;
 	case EntityTypes::JumpBoost:
 		return CreateJumpBoost(position, id);
+	case EntityTypes::Reviver:
+		return CreateReviverPickup(position, id);
 	default:
 		break;
 	}
@@ -514,6 +516,37 @@ u32 ItemManager::CreateChargeShotPickup(Vector3 position, u32 id)
 
 	auto& lerpAnimator = s_entityManager.AddComponent<PickupLerpAnimateComponent>(chargeShotEntity);
 	lerpAnimator.baseOrigin = s_entityManager.GetComponent<TransformComponent>(chargeShotEntity).GetPosition().y;
+	lerpAnimator.baseTarget = lerpAnimator.baseOrigin + 2.0f;
+	lerpAnimator.currentOrigin = lerpAnimator.baseOrigin;
+	return ni.id;
+}
+
+u32 ItemManager::CreateReviverPickup(Vector3 position, u32 id)
+{
+	static u32 reviverNetworkID = 0u;
+
+	u32 modelID = AssetManager::Get().LoadModelAsset("Assets/Models/Temporary_Assets/magenta_cube.glb");
+
+	entity reviverEntity = s_entityManager.CreateEntity();
+	s_entityManager.AddComponent<ActiveItemComponent>(reviverEntity).type = ActiveItemComponent::Type::Reviver;
+	s_entityManager.AddComponent<PickupComponent>(reviverEntity).itemName = "Reviver";
+	s_entityManager.AddComponent<ModelComponent>(reviverEntity, modelID);
+	s_entityManager.AddComponent<TransformComponent>(reviverEntity, position).SetScale({ 0.3f, 0.3f, 0.3f });
+	s_entityManager.AddComponent<ShadowReceiverComponent>(reviverEntity);
+	auto& ni = s_entityManager.AddComponent<NetworkId>(reviverEntity);
+	ni.entityTypeId = EntityTypes::Reviver;
+	if (id == 0)
+		ni.id = ++reviverNetworkID;
+	else
+	{
+		ni.id = id;
+		reviverNetworkID = id;
+	}
+
+	LuaMain::GetScriptManager()->AddScript(reviverEntity, "Pickupable.lua");
+
+	auto& lerpAnimator = s_entityManager.AddComponent<PickupLerpAnimateComponent>(reviverEntity);
+	lerpAnimator.baseOrigin = s_entityManager.GetComponent<TransformComponent>(reviverEntity).GetPosition().y;
 	lerpAnimator.baseTarget = lerpAnimator.baseOrigin + 2.0f;
 	lerpAnimator.currentOrigin = lerpAnimator.baseOrigin;
 	return ni.id;

--- a/Rogue-Robots/Runtime/src/Game/ItemManager/ItemManager.h
+++ b/Rogue-Robots/Runtime/src/Game/ItemManager/ItemManager.h
@@ -45,4 +45,5 @@ private:
 	u32 CreateJumpBoost(Vector3 position, u32 id = 0);
 	u32 CreateFullAutoPickup(Vector3 position, u32 id = 0);
 	u32 CreateChargeShotPickup(Vector3 position, u32 id = 0);
+	u32 CreateReviverPickup(Vector3 position, u32 id = 0);
 };

--- a/Rogue-Robots/Runtime/src/Game/LuaInterfaces.cpp
+++ b/Rogue-Robots/Runtime/src/Game/LuaInterfaces.cpp
@@ -348,6 +348,9 @@ void EntityInterface::GetEntityTypeAsString(DOG::LuaContext* context)
 	case EntityTypes::Turret:
 		context->ReturnString("Turret");
 		break;
+	case EntityTypes::Reviver:
+		context->ReturnString("Reviver");
+		break;
 	case EntityTypes::FrostMagazineModification:
 		context->ReturnString("FrostMagazineModification");
 		break;
@@ -466,6 +469,7 @@ const std::unordered_map<PassiveItemComponent::Type, std::string> passiveTypeMap
 const std::unordered_map<ActiveItemComponent::Type, std::string> activeTypeMap = {
 	{ ActiveItemComponent::Type::Trampoline, "Trampoline" },
 	{ ActiveItemComponent::Type::Turret, "Turret" },
+	{ ActiveItemComponent::Type::Reviver, "Reviver" },
 };
 
 const std::unordered_map<BarrelComponent::Type, std::string> barrelTypeMap = {
@@ -710,6 +714,8 @@ void EntityInterface::SpawnActiveItem(DOG::LuaContext* context)
 		ItemManager::Get().CreateItem(EntityTypes::Trampoline, EntityManager::Get().GetComponent<TransformComponent>(playerId).GetPosition());
 	else if (EntityManager::Get().GetComponent<ActiveItemComponent>(playerId).type == ActiveItemComponent::Type::Turret)
 		ItemManager::Get().CreateItem(EntityTypes::Turret, EntityManager::Get().GetComponent<TransformComponent>(playerId).GetPosition());
+	else if (EntityManager::Get().GetComponent<ActiveItemComponent>(playerId).type == ActiveItemComponent::Type::Reviver)
+		ItemManager::Get().CreateItem(EntityTypes::Reviver, EntityManager::Get().GetComponent<TransformComponent>(playerId).GetPosition());
 }
 
 void EntityInterface::AddAudio(LuaContext* context, entity e)


### PR DESCRIPTION
Functionality test:
* Try to revive a player without holding the Reviver active item component. It should not be possible.
* Try to equip the Reviver component (magenta cube model for now) and revive a player. This should now be possible.

Note that this particular active item is handled uniquely on lua-side. As such there is no activate function, rather it is left to the ECS architecture to handle. However, it IS represented on the lua-side of things.   