### PR TITLE
replace wrap filters with clamp

### DIFF
--- a/Rogue-Robots/Assets/Shaders/BlitPS.hlsl
+++ b/Rogue-Robots/Assets/Shaders/BlitPS.hlsl
@@ -23,19 +23,19 @@ CONSTANTS(g_constants, PushConstantElement)
 float4 main(VS_OUT input) : SV_TARGET
 {
     Texture2D outlineTex = ResourceDescriptorHeap[g_constants.outline];
-    float3 outline = outlineTex.Sample(g_aniso_samp, input.uv).rgb;
+    float3 outline = outlineTex.Sample(g_bilinear_clamp_samp, input.uv).rgb;
     
     
     
     Texture2D finalTex = ResourceDescriptorHeap[g_constants.finalTexID];
-    float3 hdr = finalTex.Sample(g_aniso_samp, input.uv);
+    float3 hdr = finalTex.Sample(g_bilinear_clamp_samp, input.uv);
     
     float4 ssaoColor = 1.f.rrrr;
     float ssaoContrib = 1.f;
     if (!(g_constants.ao == 0xffffffff))
     {
         Texture2D<float4> ssao = ResourceDescriptorHeap[g_constants.ao];
-        ssaoColor = ssao.Sample(g_point_samp, input.uv);
+        ssaoColor = ssao.Sample(g_point_clamp_samp, input.uv);
         ssaoContrib = uncharted2_filmic(ssaoColor.rgb).r;
     }
    
@@ -43,7 +43,7 @@ float4 main(VS_OUT input) : SV_TARGET
     if (!(g_constants.bloom == 0xffffffff))
     {
         Texture2D<float4> bloomTex = ResourceDescriptorHeap[g_constants.bloom];
-        bloom = bloomTex.Sample(g_aniso_samp, input.uv);
+        bloom = bloomTex.Sample(g_bilinear_clamp_samp, input.uv);
     }
 
     // Darken the white halos with Reinhard Jodie


### PR DESCRIPTION
This fixes the color bleed problem where colors would wrap around from one border of the screen to one other. 