### PR TITLE
Add length threshold on pickup to avoid angle checking when too close…

### DIFF
--- a/Rogue-Robots/Runtime/src/Game/GameSystems.h
+++ b/Rogue-Robots/Runtime/src/Game/GameSystems.h
@@ -155,7 +155,6 @@ public:
 		// If below a distance threshold --> Ignore look angle
 		if (pickUpToPlayer.Length() < LENGTH_THRESHOLD_TO_AVOID_ANGLE)
 		{
-			std::cout << "Close enough\n";
 			isLookingAtItem = true;
 		}
 


### PR DESCRIPTION
… to a pickup.

Check this by going into a hovering pickup (be very close to it).
Look-angle should not affect the pickup availability if too close.