### PR TITLE
Expose setting for AudioDevice master volume

### DIFF
--- a/Rogue-Robots/DOGEngine/src/Audio/Audio.h
+++ b/Rogue-Robots/DOGEngine/src/Audio/Audio.h
@@ -89,6 +89,7 @@ namespace DOG
 
 		void HandleComponent(AudioComponent& comp, entity e);
 		void Commit();
+		void SetMasterVolume(f32 volume) noexcept { m_master->SetVolume(volume); };
 
 	private:
 		void AudioThreadRoutine();

--- a/Rogue-Robots/DOGEngine/src/Audio/AudioManager.h
+++ b/Rogue-Robots/DOGEngine/src/Audio/AudioManager.h
@@ -13,6 +13,8 @@ namespace DOG
 
 		static void StopAudioOnDeferredEntities();
 
+		static void SetMasterVolume(f32 volume) noexcept { if (s_deviceInitialized) s_device->SetMasterVolume(volume); };
+
 	private:
 		static inline std::unique_ptr<AudioDevice> s_device = nullptr;
 		static inline bool s_deviceInitialized = false;


### PR DESCRIPTION
Test:
Set master volume in Application.cpp
AudioManager::SetMasterVolume(something_other_than_2)
See if it changes the volume. 
Try to disable your audio device on the computer
See that it doesn't crash