### PR TITLE
Extern test branchen!

### DIFF
--- a/Rogue-Robots/Runtime/src/Game/GameSystems.cpp
+++ b/Rogue-Robots/Runtime/src/Game/GameSystems.cpp
@@ -614,9 +614,11 @@ void ReviveSystem::RevivePlayer(DOG::entity player)
 
 	auto& psc = mgr.GetComponent<PlayerStatsComponent>(player);
 	psc.health = psc.maxHealth / 2.0f;
-
-	auto& sC = mgr.GetComponent<SpectatorComponent>(player);
-	mgr.RemoveComponentIfExists<AudioListenerComponent>(sC.playerBeingSpectated);
+	if(mgr.HasComponent<SpectatorComponent>(player))
+	{
+		auto& sC = mgr.GetComponent<SpectatorComponent>(player);
+		mgr.RemoveComponentIfExists<AudioListenerComponent>(sC.playerBeingSpectated);
+	}
 	mgr.RemoveComponent<SpectatorComponent>(player);
 	mgr.AddOrReplaceComponent<AudioListenerComponent>(player);
 


### PR DESCRIPTION
Fixed a audio issue after revives.

AudioListener component was never removed from the spectating player upon reviving.

Fixed by removing audioListenerComponent from spectating player and adding one to "thisPlayer".

AddOrReplace and RemoveIfExists was used as a security measure to ensure no crashes would occur as a result of this change. 