### PR TITLE
Dynamic ECS

### DIFF
--- a/Rogue-Robots/DOGEngine/src/ECS/EntityTypedef.h
+++ b/Rogue-Robots/DOGEngine/src/ECS/EntityTypedef.h
@@ -2,7 +2,8 @@
 
 namespace DOG
 {
-	constexpr const u32 MAX_ENTITIES = 20'000u;
-	constexpr const u32 NULL_ENTITY = MAX_ENTITIES;
+	constexpr const u32 INITIAL_ENTITY_CAPACITY = 2u; //500
+	constexpr const u32 INITIAL_COMPONENT_CAPACITY = 2u;
+	constexpr const u32 NULL_ENTITY = 100'000'000u;
 	typedef u32 entity;
 }


### PR DESCRIPTION
Dynamic ECS is now here, which is the final version for this project.

Features:
- Scales container sizes dynamically, resulting in less wasted memory space. This leads to ~10mb of saved memory.
- An arbitrary limit of 100'000'000 entities exist, however in reality it could be set to uint32_t::MAX and it would still work. Still, before reaching that limit you would probably have other problems.
- Some minor code snippets have been refactored, making the code more compact and performant without sacrificing readability.


Functionality test:
IMPORTANT: ECS IS THE BACKBONE OF THE WHOLE PROJECT. TEST THIS THOUROUGHLY (which I have already done, but so should you!).
- Build and run in all configurations, it should work like before.
- Run ALL maps (one config is enough) and see that gameplay works as before. Do random stuff, shooting, pick items, etc.
- If you DO know previous memory usage, compare to the new one. It should be roughly 10mb gain.

Aside from this do general code inspection.
